### PR TITLE
Fix buffer overrun in line input

### DIFF
--- a/sudokuSolver.c
+++ b/sudokuSolver.c
@@ -328,14 +328,14 @@ int main() {
 
     for (int row = 0; row<9; row++)
     {
-        char input[9] = "";
+        char input[100] = "";
 
         // Verify that puzzle is valid as input so far
       retry:
         // Get input from the user
         if (isatty(0))
             printf("Row %d: ", row+1);
-        scanf("%s", input);
+        scanf("%99s", input);
 
         // Verify 9 digits
         if (!isValidInput(input)) {


### PR DESCRIPTION
Line array bumped up past 9 since scanf adds a null to the end. If we
increase it to 10 then it stops the buffer overrun but we can't tell if
a line is too long or not. So making it 100 solves that problem, and
gives enough context in the error message.
